### PR TITLE
fix: add newline at the end of ./common

### DIFF
--- a/common
+++ b/common
@@ -529,3 +529,4 @@ function generate_config_archive() {
         /etc/kubernetes/admin.conf > /dev/null 2>&1
     display_message_result "Generating config archive"
 }
+


### PR DESCRIPTION
Without a newline at the end of .common, help2man fails to generate on my development machine.